### PR TITLE
Fix NuGet packing batch

### DIFF
--- a/nuget/pack.bat
+++ b/nuget/pack.bat
@@ -1,1 +1,1 @@
-dotnet pack ../src/Paidy/Paidy.csproj -c Release -o ./packages
+dotnet pack ../src/libs/Paidy/Paidy.csproj -c Release -o ./packages


### PR DESCRIPTION
This pull request updates the path to the `Paidy.csproj` file in the `nuget/pack.bat` script to reflect its new location.

* Updated the path in `nuget/pack.bat` to reference `../src/libs/Paidy/Paidy.csproj` instead of `../src/Paidy/Paidy.csproj`.